### PR TITLE
Fix for image_path

### DIFF
--- a/lib/evil_systems/helpers.rb
+++ b/lib/evil_systems/helpers.rb
@@ -11,7 +11,7 @@ module EvilSystems
     # (Rails screenshots path is not configurable https://github.com/rails/rails/blob/49baf092439fc74fc3377b12e3334c3dd9d0752f/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L79)
     # @return [String]
     def absolute_image_path
-      save_path = ::Capybara.save_path.present? || Rails.root.join("tmp/screenshots/#{image_name}")
+      save_path = ::Capybara.save_path.presence || Rails.root.join("tmp/screenshots/#{image_name}")
       return ::Rails.root.join("#{save_path}/screenshots/#{image_name}.png") if defined? ::Rails
 
       File.join("#{save_path}/screenshots/#{image_name}.png")


### PR DESCRIPTION
Previously it return true in save_path as result we have path like : `true/screenshots/0_test_super_admin_has_all_filter_role_types.png`